### PR TITLE
Change canvas API to take paths for drawing, instead of clip + fill

### DIFF
--- a/Lib/blackrenderer/backends/base.py
+++ b/Lib/blackrenderer/backends/base.py
@@ -26,21 +26,40 @@ class Canvas(ABC):
         ...
 
     @abstractmethod
-    def fillSolid(self, color):
+    def drawPathSolid(self, path, color):
         ...
 
     @abstractmethod
-    def fillLinearGradient(self, colorLine, pt1, pt2, extendMode):
-        ...
-
-    @abstractmethod
-    def fillRadialGradient(
-        self, colorLine, startCenter, startRadius, endCenter, endRadius, extendMode
+    def drawPathLinearGradient(
+        self, path, colorLine, pt1, pt2, extendMode, gradientTransform
     ):
         ...
 
     @abstractmethod
-    def fillSweepGradient(self, colorLine, center, startAngle, endAngle, extendMode):
+    def drawPathRadialGradient(
+        self,
+        path,
+        colorLine,
+        startCenter,
+        startRadius,
+        endCenter,
+        endRadius,
+        extendMode,
+        gradientTransform,
+    ):
+        ...
+
+    @abstractmethod
+    def drawPathSweepGradient(
+        self,
+        path,
+        colorLine,
+        center,
+        startAngle,
+        endAngle,
+        extendMode,
+        gradientTransform,
+    ):
         ...
 
     def translate(self, x, y):

--- a/Lib/blackrenderer/backends/skia.py
+++ b/Lib/blackrenderer/backends/skia.py
@@ -56,22 +56,42 @@ class SkiaCanvas(Canvas):
     def clipPath(self, path):
         self.canvas.clipPath(path.path, doAntiAlias=True)
 
-    def fillSolid(self, color):
-        self.canvas.drawColor(skia.Color4f(tuple(color)))
+    def drawPathSolid(self, path, color):
+        paint = skia.Paint(
+            AntiAlias=True,
+            Color=skia.Color4f(tuple(color)),
+            Style=skia.Paint.kFill_Style,
+        )
+        self.canvas.drawPath(path.path, paint)
 
-    def fillLinearGradient(self, colorLine, pt1, pt2, extendMode):
+    def drawPathLinearGradient(
+        self, path, colorLine, pt1, pt2, extendMode, gradientTransform
+    ):
+        matrix = skia.Matrix()
+        matrix.setAffine(gradientTransform)
         colors, stops = _unpackColorLine(colorLine)
         shader = skia.GradientShader.MakeLinear(
             points=[pt1, pt2],
             colors=colors,
             positions=stops,
             mode=_extendModeMap[extendMode],
+            localMatrix=matrix,
         )
-        self.canvas.drawPaint(skia.Paint(Shader=shader))
+        self.canvas.drawPath(path.path, skia.Paint(Shader=shader))
 
-    def fillRadialGradient(
-        self, colorLine, startCenter, startRadius, endCenter, endRadius, extendMode
+    def drawPathRadialGradient(
+        self,
+        path,
+        colorLine,
+        startCenter,
+        startRadius,
+        endCenter,
+        endRadius,
+        extendMode,
+        gradientTransform,
     ):
+        matrix = skia.Matrix()
+        matrix.setAffine(gradientTransform)
         colors, stops = _unpackColorLine(colorLine)
         shader = skia.GradientShader.MakeTwoPointConical(
             start=startCenter,
@@ -81,14 +101,21 @@ class SkiaCanvas(Canvas):
             colors=colors,
             positions=stops,
             mode=_extendModeMap[extendMode],
+            localMatrix=matrix,
         )
-        self.canvas.drawPaint(skia.Paint(Shader=shader))
+        self.canvas.drawPath(path.path, skia.Paint(Shader=shader))
 
-    def fillSweepGradient(self, colorLine, center, startAngle, endAngle, extendMode):
-        print("fillSweepGradient")
-        from random import random
-
-        self.fillSolid((1, random(), random(), 1))
+    def drawPathSweepGradient(
+        self,
+        path,
+        colorLine,
+        center,
+        startAngle,
+        endAngle,
+        extendMode,
+        gradientTransform,
+    ):
+        self.drawPathSolid(path, colorLine[0][1])
 
     # TODO: blendMode for PaintComposite
 

--- a/Tests/test_backends.py
+++ b/Tests/test_backends.py
@@ -1,5 +1,6 @@
 import pathlib
 import pytest
+from fontTools.misc.transform import Identity
 from fontTools.ttLib.tables.otTables import ExtendMode
 from blackrenderer.font import BlackRendererFont
 from blackrenderer.backends import getSurface
@@ -70,16 +71,12 @@ def test_colorStops(backendName, surfaceFactory, stopOffsets, extend):
     color2 = (0, 0, 1, 1)
     stop1, stop2 = stopOffsets
     colorLine = [(stop1, color1), (stop2, color2)]
-    with canvas.savedState():
-        canvas.clipPath(rectPath)
-        canvas.fillLinearGradient(colorLine, point1, point2, extend)
+    canvas.drawPathLinearGradient(rectPath, colorLine, point1, point2, extend, Identity)
 
     for pos in [200, 400]:
         rectPath = canvas.newPath()
         drawRect(rectPath, pos, 0, 1, 100)
-        with canvas.savedState():
-            canvas.clipPath(rectPath)
-            canvas.fillSolid((0, 0, 0, 1))
+        canvas.drawPathSolid(rectPath, (0, 0, 0, 1))
 
     ext = surface.fileExtension
     stopsString = "_".join(str(s) for s in stopOffsets)


### PR DESCRIPTION
This changes the Canvas API as described in #12:
- paths are drawn explicitly, instead of setting and filling a clip path
- the font driver handles a bit more state
- various Paint transforms are bundled together before being passed to the canvas

I'll let this sit here until tomorrow before I merge.