### PR TITLE
[SVG backend] Use a stack to draw COLRv0 layers

### DIFF
--- a/Lib/blackrenderer/font.py
+++ b/Lib/blackrenderer/font.py
@@ -146,7 +146,8 @@ class BlackRendererFont:
         canvas.drawPathSolid(path, self.textColor)
 
     def _drawGlyphCOLRv0(self, layers, canvas):
-        for layer in layers:
+        for i, layer in enumerate(layers):
+            canvas.drawingLayer = i
             path = canvas.newPath()
             self._drawGlyphOutline(layer.name, path)
             canvas.drawPathSolid(path, self._getColor(layer.colorID, 1))


### PR DESCRIPTION
The W3C has had this requirement for many, _many_ years. It's often ignored, such as by Skia team, with bad consequences for my font, some fonts by @khaledhosny, etc.

It has always been well known that layer-by-layer stacks must be used when rendering color fonts… https://w3c.github.io/alreq/#h_joining_and_transparency

![image](https://user-images.githubusercontent.com/838783/150175973-2fbe2d04-e6cf-46a4-9715-24b39920202d.png)

Yet almost all browsers today still fail this test:

https://w3c.github.io/i18n-tests/css-color/transparency/cursive-opacity-001.html

I propose this patch to at least fix the SVG backend for COLRv0. Time will tell if people care enough to fix it in all products.

# Failing (Skia) `--backend skia`
![image](https://user-images.githubusercontent.com/838783/150176311-848c032a-aedc-488c-bd14-f4788478b492.png)

# Passing `--backend svg`
![image](https://user-images.githubusercontent.com/838783/150176441-49194754-a3c9-4681-b695-719ece7d7143.png)

Note: Even for COLRv0 it's not a complete solution because I wasn't sure if I was allowed to call out to Skia pathops when joining `self.solidStacks`.