### PR TITLE
Retrieving full glyph drawing data from drawGlyph & PathCollector

### DIFF
--- a/Lib/blackrenderer/backends/pathCollector.py
+++ b/Lib/blackrenderer/backends/pathCollector.py
@@ -3,7 +3,15 @@ from fontTools.misc.arrayTools import calcBounds
 from fontTools.misc.transform import Identity
 from fontTools.pens.recordingPen import RecordingPen
 from fontTools.pens.transformPen import TransformPen
-from .base import Canvas
+from .base import Canvas, Surface
+
+class PathCollectorRecordingPen(RecordingPen):
+    def annotate(self, method, data):
+        self.method = method
+        self.data = data
+    
+    def __repr__(self):
+        return f"PathCollectorRecordingPen({self.method}{list(self.data.keys())})"
 
 
 class PathCollectorCanvas(Canvas):
@@ -14,13 +22,14 @@ class PathCollectorCanvas(Canvas):
         self.paths = []
         self.currentTransform = Identity
 
-    def _addPath(self, path):
+    def _addPath(self, path, method, data):
         if self.currentTransform != Identity:
             path = transformPath(path, self.currentTransform)
+        path.annotate(method, data)
         self.paths.append(path)
 
     def newPath(self):
-        return RecordingPen()
+        return PathCollectorRecordingPen()
 
     @contextmanager
     def savedState(self):
@@ -36,15 +45,21 @@ class PathCollectorCanvas(Canvas):
         self.currentTransform = self.currentTransform.transform(transform)
 
     def clipPath(self, path):
-        self._addPath(path)
+        self._addPath(path, "clipPath", dict())
 
     def drawPathSolid(self, path, color):
-        self._addPath(path)
+        self._addPath(path, "drawPathSolid", dict(color=color))
 
     def drawPathLinearGradient(
         self, path, colorLine, pt1, pt2, extendMode, gradientTransform
     ):
-        self._addPath(path)
+        self._addPath(path, "drawPathLinearGradient", dict(
+            colorLine=colorLine,
+            pt1=pt1,
+            pt2=pt2,
+            extendMode=extendMode,
+            gradientTransform=gradientTransform,
+        ))
 
     def drawPathRadialGradient(
         self,
@@ -57,7 +72,15 @@ class PathCollectorCanvas(Canvas):
         extendMode,
         gradientTransform,
     ):
-        self._addPath(path)
+        self._addPath(path, "drawPathRadialGradient", dict(
+            colorLine=colorLine,
+            startCenter=startCenter,
+            startRadius=startRadius,
+            endCenter=endCenter,
+            endRadius=endRadius,
+            extendMode=extendMode,
+            gradientTransform=gradientTransform,
+        ))
 
     def drawPathSweepGradient(
         self,
@@ -69,7 +92,31 @@ class PathCollectorCanvas(Canvas):
         extendMode,
         gradientTransform,
     ):
-        self._addPath(path)
+        self._addPath(path, "drawPathSweepGradient", dict(
+            colorLine=colorLine,
+            center=center,
+            startAngle=startAngle,
+            endAngle=endAngle,
+            extendMode=extendMode,
+            gradientTransform=gradientTransform,
+        ))
+
+
+class PathCollectorSurface(Surface):
+    fileExtension = None
+
+    def __init__(self):
+        self.paths = None
+        pass
+
+    @contextmanager
+    def canvas(self, boundingBox):
+        canvas = PathCollectorCanvas()
+        yield canvas
+        self.paths = canvas.paths
+
+    def saveImage(self, path):
+        raise Exception("PathCollectorSurface cannot be saved")
 
 
 class PointCollector:
@@ -117,4 +164,6 @@ def transformPath(path, transform):
     transformedPath = RecordingPen()
     tpen = TransformPen(transformedPath, transform)
     path.replay(tpen)
-    return transformedPath
+    # to keep the path ref the same
+    path.value = transformedPath.value
+    return path

--- a/Lib/blackrenderer/backends/pathCollector.py
+++ b/Lib/blackrenderer/backends/pathCollector.py
@@ -150,7 +150,7 @@ class BoundsCanvas(PathCollectorCanvas):
     def bounds(self):
         return calcBounds(self.points)
 
-    def _addPath(self, path):
+    def _addPath(self, path, method, data):
         points = path.points
         if self.currentTransform != Identity:
             points = self.currentTransform.transformPoints(points)

--- a/Tests/test_glyph_render.py
+++ b/Tests/test_glyph_render.py
@@ -104,7 +104,6 @@ test_glyphs = [
 @pytest.mark.parametrize("fontName, glyphName, location", test_glyphs)
 @pytest.mark.parametrize("backendName, surfaceClass", backends)
 def test_renderGlyph(backendName, surfaceClass, fontName, glyphName, location):
-    print(">>>>>>>>>>>>>>", fontName)
     font = BlackRendererFont(testFonts[fontName])
     font.setLocation(location)
 

--- a/Tests/test_glyph_render.py
+++ b/Tests/test_glyph_render.py
@@ -104,6 +104,7 @@ test_glyphs = [
 @pytest.mark.parametrize("fontName, glyphName, location", test_glyphs)
 @pytest.mark.parametrize("backendName, surfaceClass", backends)
 def test_renderGlyph(backendName, surfaceClass, fontName, glyphName, location):
+    print(">>>>>>>>>>>>>>", fontName)
     font = BlackRendererFont(testFonts[fontName])
     font.setLocation(location)
 
@@ -134,9 +135,12 @@ def _locationToString(location):
 def test_pathCollector():
     font = BlackRendererFont(testFonts["noto"])
     canvas = PathCollectorCanvas()
-    font.drawGlyph("uni2693", canvas)
+    glyph = font.drawGlyph("uni2693", canvas)
     assert len(canvas.paths) == 6
-
+    
+    assert len(glyph) == 6
+    assert glyph[0].method == "drawPathSolid"
+    assert len(glyph[0].data["color"]) == 4
 
 def test_boundsCanvas():
     font = BlackRendererFont(testFonts["mutator"])


### PR DESCRIPTION
Not sure if this PR is totally in the spirit of what BlackRenderer is aiming to do, but was chatting with @SophiaDesign about supporting COLRv1 in [Coldtype](https://github.com/coldtype/coldtype) & she suggested integrating BlackRenderer. I got to playing around with it and realized that with some minor modifications to the `drawGlyph` method & the `PathCollector`, it would be pretty easy to get all the drawing data necessary to reconstruct COLRv1 drawings in Coldtype.

Coldtype itself splits the text shaping & the text rendering steps, so the current direct-render strategy of BlackRenderer doesn't quite fit, but with a few `return`s in font.py & some extra data being saved in the PathCollector, Coldtype can retrieve what to draw and then hold off on drawing until later. (I also experimented with pulling some of BlackRenderer’s COLRv1 skia shader-mapping out into static functions that could be called from Coldtype, but that felt a little out-of-scope here. I'll admit I've only got linear gradients working properly in Coldtype at the moment, but that was the immediate goal to support animating https://github.com/SophiaDesign/Foldit)

All in all, this PR is as much of a question as it is a suggestion/feature-request. I would love to be able to call into the BlackRenderer shaping pipeline, but if all those new returns and the expanded PathCollector don't feel at home, I completely understand!

(And just for kicks here's a little end-to-end integration with Coldtype & the modified BlackRenderer:)

https://user-images.githubusercontent.com/89770/187273083-d18903f4-20fd-4b2d-addf-47395014020d.mp4
